### PR TITLE
fix NWS samecode url

### DIFF
--- a/weatheralerts/geo.py
+++ b/weatheralerts/geo.py
@@ -111,7 +111,7 @@ class SameCodes(object):
     def _get_same_codes(self):
         '''get SAME codes, load into a dict and cache'''
         same = {}
-        url = '''http://www.nws.noaa.gov/nwr/SameCode.txt'''
+        url = '''http://www.nws.noaa.gov/nwr/data/SameCode.txt'''
         # pylint: disable=E1103
         raw = requests.get(url).content.decode('utf-8')  # py3 compatibility
         for row in raw.split('\n'):


### PR DESCRIPTION
I was getting started with this project and noticed that the unit tests for geo.py and weatheralerts.py were failing.

```
======================================================================
ERROR: test_samecode_lookup_false (__main__.Test_GeoDB)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_geodb.py", line 9, in setUp
    self.geo = GeoDB()
  File "weatheralerts\geo.py", line
16, in __init__
    self.__same = SameCodes()
  File "weatheralerts\geo.py", line
93, in __init__
    self._load_same_codes()
  File "weatheralerts\geo.py", line
109, in _load_same_codes
    self._cached_same_codes()
  File "weatheralerts\geo.py", line
149, in _cached_same_codes
    self.reload()
  File "weatheralerts\geo.py", line
102, in reload
    self._load_same_codes(refresh=True)
  File "weatheralerts\geo.py", line
107, in _load_same_codes
    self._get_same_codes()
  File "weatheralerts\geo.py", line
119, in _get_same_codes
    code, local, state = str(row).strip().split(',')
ValueError: need more than 1 value to unpack

----------------------------------------------------------------------
Ran 8 tests in 0.512s

FAILED (errors=8)
```

It seems the HTTP call made in _get_same_codes() is to a dead url, found the new location here: http://www.nws.noaa.gov/nwr/data/SameCode.txt. All tests passing again after this update.
